### PR TITLE
Replace browserify with babel, and do not bundle rhumb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,14 @@ SRC = $(wildcard src/*.js)
 LIB = $(SRC:src/%.js=lib/%.js)
 TST = $(wildcard test/*.js) $(wildcard test/**/*.js)
 NPM = @npm install --local > /dev/null && touch node_modules
+OPT = --copy-files --source-maps --modules umd
 
 v  ?= patch
 
 build: node_modules $(LIB)
 lib/%.js: src/%.js
 	@mkdir -p $(@D)
-	@browserify $< --standalone $(@F:%.js=%) | uglifyjs -o $@
+	@babel $(OPT) $< -o $@
 
 node_modules: package.json
 	$(NPM)

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ node_modules: package.json
 node_modules/%:
 	$(NPM)
 
-test: build
-	@tape $(TST)
+test: build $(TST)
+	@babel-node $(shell which tape) $(TST)
 
 .nyc_output: node_modules
 	@nyc $(MAKE) test

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Organizing applications into resources",
   "main": "lib/nap.js",
   "devDependencies": {
-    "browserify": "11.1.0",
+    "babel": "5.8.23",
     "coveralls": "2.11.4",
     "d3": "3.5.6",
     "funkis": "0.2.0",

--- a/src/nap.js
+++ b/src/nap.js
@@ -1,4 +1,4 @@
-var rhumb = require('@websdk/rhumb')
+import * as rhumb from '@websdk/rhumb'
 
 var nap = { environment: {} }
   
@@ -240,4 +240,4 @@ function newWeb(){
   return web
 }
 
-module.exports = nap
+export default nap

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,7 +1,6 @@
-var nap    = require('../src/nap')
-  , test   = require('tape')
-  , get    = require('funkis').get
-  , is     = require('funkis').is
+import nap from '../src/nap'
+import test from 'tape'
+import { get, is } from 'funkis'
 
 test('API integrity', function(t) {
   t.plan(12)

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -1,5 +1,5 @@
-var test = require('tape')
-  , nap  = require('../src/nap')
+import test from 'tape'
+import nap from '../src/nap'
 
 test('Middleware should invoke for request and response', function(t) {
   t.plan(4)

--- a/test/negotiation.test.js
+++ b/test/negotiation.test.js
@@ -1,7 +1,7 @@
-var test = require('tape')
-  , nap  = require('../src/nap')
-  , dom  = require('jsdom').jsdom
-  , d3   = require('d3')
+import test from 'tape'
+import nap from '../src/nap'
+import { jsdom as dom } from 'jsdom'
+import d3 from 'd3'
 
 test('Content negotiation by selector should call the correct handler', selectorSetup(function(t, node) {
   t.plan(2)
@@ -100,7 +100,7 @@ test('Content negotiation by method and media type should work', function(t) {
 
 function selectorSetup(test) {
   return function(t) {
-    node = d3.select(dom().body)
+    let node = d3.select(dom().body)
       .append('div')
       .classed('nap-tests', true)
 

--- a/test/requests.test.js
+++ b/test/requests.test.js
@@ -1,5 +1,5 @@
-var test = require('tape')
-  , nap  = require('../src/nap')
+import test from 'tape'
+import nap from '../src/nap'
 
 test("Requests should take callback for responses", function(t){
   t.plan(2)

--- a/test/responses.test.js
+++ b/test/responses.test.js
@@ -1,5 +1,5 @@
-var nap    = require('../src/nap')
-  , test   = require('tape')
+import test from 'tape'
+import nap from '../src/nap'
 
 test("Responding ok should yield a successful response", function(t) {
   t.plan(1)

--- a/test/uri.test.js
+++ b/test/uri.test.js
@@ -1,5 +1,5 @@
-var test = require('tape')
-  , nap  = require('../src/nap')
+import test from 'tape'
+import nap from '../src/nap'
 
 test('Simple URI patterns', function(t) {
   t.plan(2)

--- a/test/views.test.js
+++ b/test/views.test.js
@@ -1,7 +1,7 @@
-var test = require('tape')
-  , nap  = require('../src/nap')
-  , dom  = require('jsdom').jsdom
-  , d3   = require('d3')
+import test from 'tape'
+import nap from '../src/nap'
+import { jsdom as dom } from 'jsdom'
+import d3 from 'd3'
 
 test('nap.into a dom node should invoke the response body on that node', setup(function(t, node) {
   t.plan(1)
@@ -48,7 +48,7 @@ test("should do nothing if the content type is not a nap view", setup(function(t
 
 function setup(test) {
   return function(t) {
-    node = d3.select(dom().body)
+    let node = d3.select(dom().body)
       .append("div")
       .classed("nap-tests", true)
       .node()

--- a/test/web.test.js
+++ b/test/web.test.js
@@ -1,6 +1,6 @@
-var nap    = require('../src/nap')
-  , test   = require('tape')
-  , get    = require('funkis').get
+import test from 'tape'
+import nap from '../src/nap'
+import { get } from 'funkis'
 
 test('Web instances', function(t) {
   t.plan(1)


### PR DESCRIPTION
This marks the beginning of work to bring nap into ES6 land.
To accompany this work, there's a [branch of nap-examples](https://github.com/websdk/nap-examples/tree/unbundled-nap) to
show and test how compiled nap works.
