### PR TITLE
Add metadata to resources, and the ability to find them by path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websdk/nap",
-  "version": "0.10.7",
+  "version": "0.11.0",
   "description": "Organizing applications into resources",
   "main": "lib/nap.js",
   "devDependencies": {

--- a/test/web.test.js
+++ b/test/web.test.js
@@ -85,6 +85,39 @@ test('Web resource handlers should invoke a response callback if given', functio
   })
 })
 
+test('Web should return handler, params, and metadata when finding a resource by path', function(t) {
+  t.plan(12)
+  var web  = nap.web()
+    , fn_a = function() {}
+    , fn_b = function() {}
+    , fn_c = function() {}
+    , fn_d = function() {}
+
+  web.resource('/no/metadata/no/params', fn_a)
+  var a = web.find('/no/metadata/no/params')
+  t.equal(a.fn, fn_a)
+  t.deepEqual(a.params, {})
+  t.deepEqual(a.metadata, {})
+
+  web.resource('/with/metadata/no/params', fn_b, { foo: 'bar' })
+  var b = web.find('/with/metadata/no/params')
+  t.equal(b.fn, fn_b)
+  t.deepEqual(b.params, {})
+  t.deepEqual(b.metadata, { foo: 'bar' })
+
+  web.resource('/{with}/metadata/and/{params}', fn_c, { baz: 'wibble' })
+  var c = web.find('/some/metadata/and/fun')
+  t.equal(c.fn, fn_c)
+  t.deepEqual(c.params, { with: 'some', params: 'fun' })
+  t.deepEqual(c.metadata, { baz: 'wibble' })
+
+  web.resource('named', '/also/{with}/metadata/and/{params}', fn_d, { boo: 'moo' })
+  var d = web.find('/also/some/metadata/and/fun')
+  t.equal(d.fn, fn_d)
+  t.deepEqual(d.params, { with: 'some', params: 'fun' })
+  t.deepEqual(d.metadata, { boo: 'moo' })
+})
+
 test("Web should respond with a 404 if no resource is found", function(t) {
   t.plan(1)
   var web = nap.web()


### PR DESCRIPTION
This adds the option of adding a metadata object when registering
a resource definition. The metadata won't actually be used, other
than returned when calling `web.find` which is a new method to
find resource definitions by path as opposed to by name.
