### PR TITLE
Exclude rhumb from the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ node_js:
   - "iojs"
   - "4"
 
-before_install: echo "PATH = $PATH"
 install: make clean build
 script: make test
 after_success: make coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
   - "iojs"
   - "4"
 
+before_install: echo "PATH = $PATH"
 install: make clean build
 script: make test
 after_success: make coverage

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ v  ?= patch
 build: node_modules $(LIB)
 lib/%.js: src/%.js
 	@mkdir -p $(@D)
-	@browserify $< --standalone $(@F:%.js=%) | uglifyjs -o $@
+	@browserify --exclude @websdk/rhumb $< --standalone $(@F:%.js=%) > $@
 
 node_modules: package.json
 	$(NPM)

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,17 @@
 SHELL := /bin/bash
+PATH  := $(shell echo $${PATH//\.\/node_modules\/\.bin:/}):node_modules/.bin
 
 SRC = $(wildcard src/*.js)
 LIB = $(SRC:src/%.js=lib/%.js)
 TST = $(wildcard test/*.js) $(wildcard test/**/*.js)
 NPM = @npm install --local > /dev/null && touch node_modules
 
-NM  = node_modules/.bin
-
 v  ?= patch
 
 build: node_modules $(LIB)
 lib/%.js: src/%.js
 	@mkdir -p $(@D)
-	@$(NM)/browserify --exclude @websdk/rhumb $< --standalone $(@F:%.js=%) > $@
+	@browserify --exclude @websdk/rhumb $< --standalone $(@F:%.js=%) > $@
 
 node_modules: package.json
 	$(NPM)
@@ -20,16 +19,16 @@ node_modules/%:
 	$(NPM)
 
 test: build
-	@$(NM)/tape $(TST)
+	@tape $(TST)
 
 .nyc_output: node_modules
-	@$(NM)/nyc $(MAKE) test
+	@nyc $(MAKE) test
 
 coverage: .nyc_output
-	@$(NM)/nyc report --reporter=text-lcov | $(NM)/coveralls
+	@nyc report --reporter=text-lcov | coveralls
 
 dev: node_modules
-	@$(NM)/nodemon -q -x "(clear; $(NM)/nyc $(MAKE) test | $(NM)/tap-dot && $(NM)/nyc report) || true"
+	@nodemon -q -x "(clear; nyc $(MAKE) test | tap-dot && nyc report) || true"
 
 release: clean build test
 	@npm version $(v)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PATH  := node_modules/.bin:$(PATH)
+PATH  := $(PATH):node_modules/.bin
 SHELL := /bin/bash
 
 SRC = $(wildcard src/*.js)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-PATH  := $(PATH):node_modules/.bin
 SHELL := /bin/bash
 
 SRC = $(wildcard src/*.js)
@@ -6,12 +5,14 @@ LIB = $(SRC:src/%.js=lib/%.js)
 TST = $(wildcard test/*.js) $(wildcard test/**/*.js)
 NPM = @npm install --local > /dev/null && touch node_modules
 
+NM  = node_modules/.bin
+
 v  ?= patch
 
 build: node_modules $(LIB)
 lib/%.js: src/%.js
 	@mkdir -p $(@D)
-	@browserify --exclude @websdk/rhumb $< --standalone $(@F:%.js=%) > $@
+	@$(NM)/browserify --exclude @websdk/rhumb $< --standalone $(@F:%.js=%) > $@
 
 node_modules: package.json
 	$(NPM)
@@ -19,16 +20,16 @@ node_modules/%:
 	$(NPM)
 
 test: build
-	@tape $(TST)
+	@$(NM)/tape $(TST)
 
 .nyc_output: node_modules
-	@nyc $(MAKE) test
+	@$(NM)/nyc $(MAKE) test
 
 coverage: .nyc_output
-	@nyc report --reporter=text-lcov | coveralls
+	@$(NM)/nyc report --reporter=text-lcov | $(NM)/coveralls
 
 dev: node_modules
-	@nodemon -q -x "(clear; nyc $(MAKE) test | tap-dot && nyc report) || true"
+	@$(NM)/nodemon -q -x "(clear; $(NM)/nyc $(MAKE) test | $(NM)/tap-dot && $(NM)/nyc report) || true"
 
 release: clean build test
 	@npm version $(v)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websdk/nap",
-  "version": "0.9.8",
+  "version": "0.10.0",
   "description": "Organizing applications into resources",
   "main": "lib/nap.js",
   "devDependencies": {


### PR DESCRIPTION
@grancalavera this oughta do it. When we merge this, we should also merge this: websdk/nap-examples#1.
