### PR TITLE
Fix #26 by replacing browserify with babel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,15 @@ PATH  := $(shell echo $${PATH//\.\/node_modules\/\.bin:/}):node_modules/.bin
 SRC = $(wildcard src/*.js)
 LIB = $(SRC:src/%.js=lib/%.js)
 TST = $(wildcard test/*.js) $(wildcard test/**/*.js)
-NPM = @npm install --local > /dev/null && touch node_modules
+NPM = @npm install --local && touch node_modules
+OPT = --plugins transform-es2015-modules-umd --copy-files --source-maps
 
 v  ?= patch
 
 build: node_modules $(LIB)
 lib/%.js: src/%.js
 	@mkdir -p $(@D)
-	@browserify --exclude @websdk/rhumb $< --standalone $(@F:%.js=%) > $@
+	@babel $(OPT) -o $@ $<
 
 node_modules: package.json
 	$(NPM)

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "nyc": "3.2.2",
     "tap-dot": "1.0.0",
     "tape": "4.2.1",
-    "uglifyjs": "2.4.10"
+    "uglifyjs": "2.4.10",
+    "babel-cli": "6.1.4",
+    "babel-plugin-transform-es2015-modules-umd": "6.1.4"
   },
   "dependencies": {
     "@websdk/rhumb": "0.3.4"


### PR DESCRIPTION
Because of browserify's boilerplate, consuming it with _other_
bundling tools such as webpack causes some issues (see #26.)
By replacing browserify with babel, we get the benefit of simpler
UMD boilerplate, as _well_ as a path forward to turn nap into
an ES6 based code based.
