### PR TITLE
Upgrade to rhumb 0.3.5 following websdk/rhumb#12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websdk/nap",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Organizing applications into resources",
   "main": "lib/nap.js",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "babel-plugin-transform-es2015-modules-umd": "6.1.4"
   },
   "dependencies": {
-    "@websdk/rhumb": "0.3.4"
+    "@websdk/rhumb": "0.3.5"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Simple bump of the rhumb dependency, which now also uses babel for builds.
