### PR TITLE
Support ? and / as valid characters in params

### DIFF
--- a/src/nap.js
+++ b/src/nap.js
@@ -240,7 +240,7 @@ function newWeb(){
     return parts.reduce(
       function(uri, part){
         if(part.type == "var"){
-          return [uri , params[part.input]].join("/")  
+          return [uri, encodeURIComponent(params[part.input])].join("/")
         }
         return part.input === '/' ? uri : [uri , part.input].join("/")
       }
@@ -251,7 +251,14 @@ function newWeb(){
   return web
 
   function find(path) {
-    return routes.match(path)
+    var match = routes.match(path)
+
+    if(match) {
+      Object.keys(match.params).forEach(function(key) {
+        match.params[key] = decodeURIComponent(match.params[key])
+      })
+    }
+    return match
   }
 }
 

--- a/test/uri.test.js
+++ b/test/uri.test.js
@@ -12,10 +12,11 @@ test('Simple URI patterns', function(t) {
 })
 
 test('Complex URI patterns', function(t) {
-  t.plan(3)
+  t.plan(4)
   var web = nap.web().resource('demo', '/my-demo/{id}', function(){})
 
   t.equal(web.uri('demo', { id : 'foo' }), '/my-demo/foo', 'should generate a URI based on resource name and params')
   t.equal(web.uri("/my-demo/{id}", { id : "foo" }), '/my-demo/foo', 'should generate a URI based on resource path and params')
   t.equal(web.uri("/my-demo/bar", { id : "foo" }), '/my-demo/bar', 'should be non-destructive if no variable parts present')
+  t.equal(web.uri("/my-demo/{id}", { id : 'foo?bar/baz' }), '/my-demo/foo%3Fbar%2Fbaz', 'should encode params')
 })

--- a/test/web.test.js
+++ b/test/web.test.js
@@ -84,12 +84,13 @@ test('Web resource handlers should invoke a response callback if given', functio
 })
 
 test('Web should return handler, params, and metadata when finding a resource by path', function(t) {
-  t.plan(12)
+  t.plan(15)
   var web  = nap.web()
     , fn_a = function() { t.ok(true, 'resource a handler will be called') }
     , fn_b = function() { t.ok(true, 'resource b handler will be called') }
     , fn_c = function() { t.ok(true, 'resource c handler will be called') }
     , fn_d = function() { t.ok(true, 'resource d handler will be called') }
+    , fn_e = function() { t.ok(true, 'resource e handler will be called') }
 
   web.resource('/no/metadata/no/params', fn_a)
   var a = web.find('/no/metadata/no/params')
@@ -114,6 +115,12 @@ test('Web should return handler, params, and metadata when finding a resource by
   d.fn()
   t.deepEqual(d.params, { with: 'some', params: 'fun' }, 'resource d params exists')
   t.deepEqual(d.metadata, { boo: 'moo' }, 'resource d metadata exists')
+
+  web.resource('/{with}/metadata/and/{params}', fn_e, { cat: 'dog' })
+  var e = web.find('/random%3Fchars/metadata/and/complex%2Fstuff')
+  e.fn()
+  t.deepEqual(e.params, { with: 'random?chars', params: 'complex/stuff' }, 'resource e params exists')
+  t.deepEqual(e.metadata, { cat: 'dog' }, 'resource e metadata exists')
 })
 
 test("Web should respond with a 404 if no resource is found", function(t) {


### PR DESCRIPTION
Introduce the encoding of resource params, so params can contain "?" and "/" and still match routes

## Description

Given I have the following params (in json):

```json
{
  "id": "random?chars",
  "name": "catchy/name"
}
```
When I create a web resource:

```javascript
var web = nap.web()
web.resource('/load/{id}/with/{name}', callback)
```

and I build my URI:

```javascript
var myUri = web.uri('/{load/{id}/with/{name}', { "id": "random?chars",  "name": "catchy/name" })
```

then the following should work:

```javascript
// Using tape
expect.plan(2)

var myCallback(req) {
  expect.equal(req.params.id, 'random?chars' , 'my random chars went through')
  expect.equal(req.params.name, 'catchy/name', 'my catchy name went through')
}

var req = web.find(myUri)
req.fn(req)
```

## Motivation and Context

This PR exists because my expectation was not met.

1. I would like to use nap and trust that I can pass a "?" as a character in my params and still have the request match.  The ? would cause the rest of the uri to be treated as a uri query and not part of the path.
1. I would like to use nap and trust that I can pass a "#" as a character in my params and still have the request match.  The / would not be encoded so would seen as part of the path and not match the resource.

## How Was This Tested?
Tested with unit tests.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change follows the style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
